### PR TITLE
Adding link to map2model in README.md for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ Before starting, please ensure you have the following installed:
 
 ### Adding new specifications
 
-If you have created a new specification (or a specification is missing from the *map2model > docs > specification_md_files* folder) you will need to extend the *map2model > spec2model > configuration.yml* file.
+If you have created a new specification (or a specification is missing from the 
+*[map2model](https://github.com/BioSchemas/map2model) > docs > specification_md_files* folder) 
+you will need to extend the *[map2model](https://github.com/BioSchemas/map2model) > spec2model > configuration.yml* file.
 
 If you are unfamiliar with yaml, please read [http://yaml.org/](http://yaml.org/).
 
-1. Open the *map2model > spec2model > [configuration.yml](https://github.com/BioSchemas/map2model/blob/master/spec2model/configuration.yml)* file.
+1. Open the *[map2model](https://github.com/BioSchemas/map2model) > spec2model > [configuration.yml](https://github.com/BioSchemas/map2model/blob/master/spec2model/configuration.yml)* file.
 1. Erase all the file content and start the ```.yml``` file with
 ```
 specifications:

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Before starting, please ensure you have the following installed:
 1. Install Python dependencies using the command ```pip3 install -r requirements.txt```.
 1. Run the map2model module by executing the command ```python3 run.py```.
 1. After executing the ```run.py``` command a web browser will ask for a Google Account authentication. **Log in using the account you used for step 2.**
-1. Once complete, the specifications can be found in a subfolder inside *map2model > docs > spec_files* folder. There should be a folder for each specification listed in ```configuration.yml```.
+1. Once complete, the specifications can be found in a subfolder inside *map2model > spec2model* folder. There should be a folder for each specification listed in ```configuration.yml```.
 
 ### Update specifications repository
 
 1. Fork [Bioschemas specification repository](https://github.com/BioSchemas/specifications)
 1. Clone your fork to your local computer.
-1. If you added a new specification, copy the entire folder from *map2model > docs > spec_files* into the top level of the local copy of **specifications**.
-1. If you changed an existing specification copy the *specification.html* file from the specification subfolder in *map2model > docs > spec_files* into the appropriate specification folder in the local **specifications** repo.
+1. If you added a new specification, copy the entire folder from *map2model > spec2model* into the top level of the local copy of **specifications**.
+1. If you changed an existing specification copy the *specification.html* file from the specification subfolder in *map2model > spec2model* into the appropriate specification folder in the local **specifications** repo.
 1. Check everything is OK. If it is, commit your changes. Then push to the GitHub hosted version of your fork.
 1. Make a **Pull Request** of your specifications repository fork:
       - Go to the GitHub webpage and choose your fork of the main **specifications** repository.


### PR DESCRIPTION
This is a soft detail, but I just hit a confusing point when I was working in the `specifications` repository, and linked to the README here (without realizing I had jumped to a different repository). My workflow looked like this:

 1. Fork and clone [specifications](https://github.com/BioSchemas/specifications) to work locally
 2. Find link in instructions for "Share your Specifications" that took me to a different repository (and nope, I didn't look down to see a link to map2repo and I didn't know it was another thing)

![image](https://user-images.githubusercontent.com/814322/45588313-db865880-b8e0-11e8-94b9-61e68bf5e738.png)

 3. I then am following instructions that are far down in the README so I don't know that I'm in a different place! I actually was taken [here](https://github.com/BioSchemas/map2model#update-specifications-repository) and following instructions (I had already cloned specifications repository).

When it mentioned some map2model docs folder I of course went back to my local specifications repo (because in my mind I was still working there) and did an `ls` and oh no! There is no matching folder, not even docs. Dinosaur panic ensues. 

I would like to suggest a really stupid and simple fix, adding links in this exact section so my attention will be drawn to them, and I'll realize that I need to clone another repository:

![image](https://user-images.githubusercontent.com/814322/45588290-69157880-b8e0-11e8-8e76-b0437fb6729f.png)

That's it! Incredibly simple, but I have a feeling others might hit this same issue and bother you with a ticket about it.
